### PR TITLE
Clean up geocoder

### DIFF
--- a/client/src/components/Header/SearchBar.tsx
+++ b/client/src/components/Header/SearchBar.tsx
@@ -26,6 +26,10 @@ function SearchBar() {
           zoom: 16,
         });
       });
+
+      return () => {
+        mapInstance.removeControl(geocoder);
+      }
     }
   }, [mapInstance]);
 

--- a/client/src/components/Header/SearchBar.tsx
+++ b/client/src/components/Header/SearchBar.tsx
@@ -29,7 +29,7 @@ function SearchBar() {
 
       return () => {
         mapInstance.removeControl(geocoder);
-      }
+      };
     }
   }, [mapInstance]);
 


### PR DESCRIPTION
Cleans up geocoder in useEffect to fix multiple search bars when rerendering.